### PR TITLE
update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ This is a Dockerfile setup for plex with plexpass - http://plex.tv/
 To run the latest plexpass version:
 
 ```
-docker run -d --net="host" --name="plex" -v /path/to/plex/config:/config -v /path/to/video/files:/data -v /etc/localtime:/etc/localtime:ro -p 32400:32400 needo/plex
+docker run -d --net="host" --name="plex" -v /path/to/plex/config:/config -v /path/to/video/files:/data -v /etc/localtime:/etc/localtime:ro needo/plex
 ```
 
 If you would like to specify a specific version of plex to run:
 
 ```
-docker run -d --net="host" --name="plex" -v /path/to/plex/config:/config -v /path/to/video/files:/data -v /etc/localtime:/etc/localtime:ro -e VERSION=0.9.9.8.436-8abe5c0 -p 32400:32400 needo/plex
+docker run -d --net="host" --name="plex" -v /path/to/plex/config:/config -v /path/to/video/files:/data -v /etc/localtime:/etc/localtime:ro -e VERSION=0.9.9.8.436-8abe5c0 needo/plex
 ```
 
 NOTE: It *must* be the full version name (i.e. 0.9.9.8.436-8abe5c0) replace with the version you desire in the command above


### PR DESCRIPTION
since the `docker run` command uses option `--net="host"` there is no need to forward ports
