### PR TITLE
Removing lines that appear to only cause error messages

### DIFF
--- a/firstrun.sh
+++ b/firstrun.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-mkdir -p /var/run/dbus
-chown messagebus:messagebus /var/run/dbus
-dbus-uuidgen --ensure
-dbus-daemon --system --fork
-sleep 1
-
-avahi-daemon -D
-sleep 1
-
 # Check to see what version of Plex is installed vs what is being requested. If requested version is different
 # install that one 
 


### PR DESCRIPTION
These are the lines that show up in the logs:

**\* Running /etc/my_init.d/firstrun.sh...
chown: invalid user: 'messagebus:messagebus'
/etc/my_init.d/firstrun.sh: line 5: dbus-uuidgen: command not found
/etc/my_init.d/firstrun.sh: line 6: dbus-daemon: command not found
/etc/my_init.d/firstrun.sh: line 9: avahi-daemon: command not found
Version not specified.
