### PR TITLE
Handle failed downloads gracefully

### DIFF
--- a/firstrun.sh
+++ b/firstrun.sh
@@ -20,10 +20,16 @@ if [ "$PLEX_VERSION" = "$INSTALLED" ]; then
     echo "Version not changed - $PLEX_VERSION"
 else
     echo "Updating to $PLEX_VERSION from $INSTALLED"
-    mv /etc/default/plexmediaserver /tmp/
-    apt-get remove --purge -y plexmediaserver
-    wget -P /tmp "${PLEX_URL}"
-    gdebi -n /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
-    mv /tmp/plexmediaserver /etc/default/
-    rm -f /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
+    # Don't uninstall the old version of plex if the download fails
+    wget -q -P /tmp "${PLEX_URL}" -O plexmediaserver_${PLEX_VERSION}_amd64.deb
+    if [ $? -eq 0 ]; then
+        mv /etc/default/plexmediaserver /tmp/
+        apt-get remove --purge -y plexmediaserver
+        gdebi -n /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
+        mv /tmp/plexmediaserver /etc/default/
+        rm -f /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
+        echo $PLEX_VERSION > /tmp/version
+    else
+        echo "Download failed, please try again later"
+    fi
 fi

--- a/installplex.sh
+++ b/installplex.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 if [ -z "$VERSION" ]; then
     PLEX_URL=$(curl -sL http://plex.baconopolis.net/latest.php | sed -nr 's#(http.+?/plexmediaserver_.+?_amd64\.deb)#\1#p')
 else
@@ -13,7 +14,11 @@ fi
 
 echo Installing Plex Media Server $PLEX_VERSION
 
-wget -P /tmp "$PLEX_URL"
-gdebi -n /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
-rm -f /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
-echo $PLEX_VERSION > /tmp/version
+wget -q -P /tmp "$PLEX_URL" -O plexmediaserver_${PLEX_VERSION}_amd64.deb
+if [ $? -eq 0 ]; then
+    gdebi -n /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
+    rm -f /tmp/plexmediaserver_${PLEX_VERSION}_amd64.deb
+    echo $PLEX_VERSION > /tmp/version
+else
+    echo "ERROR! Problem downloading Plex"
+fi


### PR DESCRIPTION
Don't uninstall old version of Plex if the download fails, quiet output on download so it doesn't spam log file, update /tmp/version when updating, and added shebang to installplex.sh file

Also now overwrites old file on download since wget appears to auto append .1 if the file already exists if the -O param isn't specified.