### PR TITLE
Updating Phusion Baseimage to disable SSHd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.15
+FROM phusion/baseimage:0.9.18
 MAINTAINER needo <needo@superhero.org>
 #Based on the work of Eric Schultz <eric@startuperic.com>
 #Thanks to Tim Haak <tim@haak.co.uk>


### PR DESCRIPTION
Updating to the latest Phusion Baseimage. 

This disables sshd by default and makes running with --net="host" much easier

Previously I would fill up error log files if running --net="host" since the sshd in the image would clash with the sshd in the host. Phusion disabled sshd by default now, as of 0.9.16.

You can pull the image and try it out here: https://hub.docker.com/r/brgaulin/plex/

So far it is working well
